### PR TITLE
Update action.yml to use the gilmourspace fork.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: Clone swift-format
       uses: actions/checkout@v3
       with:
-        repository: apple/swift-format
+        repository: gilmourspace/swift-format
         ref: ${{ inputs.ref }}  
         path: swift-format
 


### PR DESCRIPTION
There was an issue with swift-format using swift 5.7. A fork has been created that rectifies the issue. This change will make the workflow use the fork instead of the apple repo.